### PR TITLE
Fix the default for "expand" being a string instead of a boolean

### DIFF
--- a/schemas/1.14.json
+++ b/schemas/1.14.json
@@ -116,7 +116,7 @@
         {
           "id": "expand",
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "translate": "entry.expand",
           "help": true,
           "require": [

--- a/schemas/1.15.json
+++ b/schemas/1.15.json
@@ -278,7 +278,7 @@
         {
           "id": "expand",
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "translate": "entry.expand",
           "help": true,
           "require": [

--- a/schemas/1.16.json
+++ b/schemas/1.16.json
@@ -278,7 +278,7 @@
         {
           "id": "expand",
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "translate": "entry.expand",
           "help": true,
           "require": [


### PR DESCRIPTION
Previously, the default value was `"false"`, which *can* be parsed by Minecraft but isn't ideal. Other boolean values, such as `"treasure"`, correctly have boolean defaults.