### PR TITLE
Allow an undefined seed for the biomesource renderer.

### DIFF
--- a/src/app/previews/BiomeSource.ts
+++ b/src/app/previews/BiomeSource.ts
@@ -11,7 +11,7 @@ type BiomeSourceOptions = {
 	offset: [number, number],
 	scale: number,
 	res: number,
-	seed: bigint,
+	seed: bigint | undefined,
 	version: VersionId,
 }
 
@@ -50,6 +50,9 @@ export async function getBiome(state: any, x: number, z: number, options: BiomeS
 }
 
 async function getCached(state: any, options: BiomeSourceOptions): Promise<{ biomeSource: BiomeSource, climateSampler: Climate.Sampler }> {
+	if(options.seed == undefined) {
+		options.seed = Math.random() * (1000000 - 0) + 0
+	}
 	const newState = [state, options.octaves, `${options.seed}`, options.version]
 	if (!deepEqual(newState, cacheState)) {
 		cacheState = deepClone(newState)


### PR DESCRIPTION
Allows entry of SeedyBehaviour modified dimension jsons.
SeedyBehaviour is a fabric mod that links the dimension seed to the overworld seed - meaning the seed value is ignored.

More info: https://github.com/Haven-King/seedy-behavior

## Fix

This PR gets a random big int and prevents a "cannot cast undefined to BigInt" error.