### PR TITLE
Added Spanish to locale config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -9,6 +9,10 @@
       "name": "English"
     },
     {
+      "code": "es",
+      "name": "Español"
+    },
+    {
       "code": "fr",
       "name": "Français"
     },


### PR DESCRIPTION
Spanish is missing from the language translation drop-down menu.