### PR TITLE
Add japanese font

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP&display=swap');
 :root {
 	--background-1: #1b1b1b;
 	--background-2: #252525;
@@ -128,7 +129,7 @@ a svg {
 
 body {
 	font-size: 18px;
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: Arial, Helvetica,'IBM Plex Sans JP', sans-serif;
 	min-height: 100vh;
 	overflow-x: hidden;
 	background-color: var(--background-1);


### PR DESCRIPTION
# Added japanese font
- font: [IBM Plex Sans JP](https://www.ibm.com/blogs/think/jp-ja/how-ibm-plex-an-opensource-font-was-born/)
- license: [Open Font License](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL).
- from: [Fonts Google](https://fonts.google.com/specimen/IBM+Plex+Sans+JP/)
<h1>Before</h1>
<img src="https://user-images.githubusercontent.com/99100129/216953352-ebb9d3bb-862c-4494-80f6-92ad9191860a.png" width=1024 alt="Before Image">
<h1>After</h1>
<img src="https://user-images.githubusercontent.com/99100129/216952946-60faf872-bb43-419e-8f83-08d1401fcfef.png" width=1024 alt="After Image">
