### PR TITLE
Add fabric:dependency_overrides generator

### DIFF
--- a/public/mcdoc/fabric.mcdoc
+++ b/public/mcdoc/fabric.mcdoc
@@ -130,3 +130,39 @@ struct LanguageAdapters {
 struct CustomValues {
 	[string]: any,
 }
+
+// Sources:
+// - https://wiki.fabricmc.net/tutorial:dependency_overrides
+// - https://github.com/FabricMC/fabric-loader/blob/master/src/main/java/net/fabricmc/loader/impl/metadata/DependencyOverrides.java
+
+dispatch minecraft:resource[fabric:dependency_overrides] to struct DependencyOverrides {
+	/// Needed for internal mechanisms. Must always be `1`.
+	version: 1,
+	overrides: Overrides,
+}
+
+struct Overrides {
+	[string]: Override,
+}
+
+struct Override {
+	[DependencyType]: Dependencies,
+}
+
+enum(string) DependencyType {
+	ReplaceDepends = "depends",
+	ReplaceRecommends = "recommends",
+	ReplaceSuggests = "suggests",
+	ReplaceConflicts = "conflicts",
+	ReplaceBreaks = "breaks",
+	AddDepends = "+depends",
+	AddRecommends = "+recommends",
+	AddSuggests = "+suggests",
+	AddConflicts = "+conflicts",
+	AddBreaks = "+breaks",
+	RemoveDepends = "-depends",
+	RemoveRecommends = "-recommends",
+	RemoveSuggests = "-suggests",
+	RemoveConflicts = "-conflicts",
+	RemoveBreaks = "-breaks",
+}

--- a/src/config.json
+++ b/src/config.json
@@ -687,6 +687,14 @@
       "wiki": "https://wiki.fabricmc.net/documentation:fabric_mod_json"
     },
     {
+      "id": "fabric:dependency_overrides",
+      "url": "fabric/dependency-overrides",
+      "noPath": true,
+      "tags": ["partners"],
+      "dependency": "fabric",
+      "wiki": "https://wiki.fabricmc.net/tutorial:dependency_overrides"
+    },
+    {
       "id": "immersive_weathering:block_growth",
       "url": "immersive-weathering/block-growth",
       "path": "block_growths",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -80,6 +80,7 @@
   "generator.error_max_version": "This generator is not available in versions above %0%",
   "generator.error_min_version": "The minimum version for this generator is %0%",
   "generator.fabric:fabric_mod_json": "fabric.mod.json",
+  "generator.fabric:dependency_overrides": "fabric_loader_dependencies.json",
   "generator.font": "Font",
   "generator.frog_variant": "Frog Variant",
   "generator.immersive_weathering:block_growth": "Block Growth",


### PR DESCRIPTION
Very simple generator  for https://wiki.fabricmc.net/tutorial:dependency_overrides

In recent versions with small "hotfixes" (eg. 1.21 & 1.21.1 or 1.21.6 & 1.21.7) I regularly have to redirect people to this wiki to explain them how to get mods with versions restrictions working. It will be easier to just share an example in this generator!