### PR TITLE
WIP: support different versions in the customized selector

### DIFF
--- a/src/app/components/customized/BiomesSettings.tsx
+++ b/src/app/components/customized/BiomesSettings.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'preact/hooks'
+import { useVersion } from '../../contexts/Version.jsx'
 import { deepClone } from '../../Utils.js'
 import { useAsync } from '../../hooks/useAsync.js'
 import { fetchRegistries } from '../../services/DataFetcher.js'
@@ -13,7 +14,11 @@ interface Props {
 	changeModel: (model: Partial<CustomizedModel>) => void,
 }
 export function BiomesSettings({ model, initialModel, changeModel }: Props) {
-	const { value: registries } = useAsync(() => fetchRegistries('1.20'))
+	const { version } = useVersion()
+	const { value: registries } = useAsync(async () => {
+		const registries = await fetchRegistries(version)
+		return registries
+	}, [version])
 
 	const biomes = useMemo(() => {
 		const hiddenBiomes = new Set(['end_barrens', 'end_highlands', 'end_midlands', 'small_end_islands', 'the_end', 'basalt_deltas', 'crimson_forest', 'nether_wastes', 'soul_sand_valley', 'warped_forest', 'the_void'])
@@ -105,6 +110,7 @@ const DefaultReplacements: Record<string, string> = {
 	old_growth_birch_forest: 'birch_forest',
 	old_growth_pine_taiga: 'taiga',
 	old_growth_spruce_taiga: 'taiga',
+	pale_garden: 'forest',
 	plains: 'the_void',
 	river: 'plains',
 	savanna: 'plains',

--- a/src/app/components/previews/BiomeSourcePreview.tsx
+++ b/src/app/components/previews/BiomeSourcePreview.tsx
@@ -272,4 +272,5 @@ export const VanillaColors: Record<string, Triple> = {
 	'minecraft:dripstone_caves': [140, 124, 0],
 	'minecraft:deep_dark': [10, 14, 19],
 	'minecraft:mangrove_swamp': [36,196,142],
+	'minecraft:pale_garden': [172, 196, 224],
 }


### PR DESCRIPTION
Hey @misode! Thanks for the very handy website :)

I was looking at https://misode.github.io/customized/?tab=biomes and noticed it didn't have the Pale Garden listed, so checked it out and found a hardcoded version that generator is pulling from + no default entry for the Pale Garden. I've added them in here and also added a colour for the Pale Garden in the renders. (This colour was arbitrary, not sure if you have a scheme.)

This generator will now pull from the provided version, i.e., will get the Pale Garden when a version is selected after it was released, but I couldn't quite get it to work smoothly... on my local development host to switch between versions you have to reload after selecting a different version. I had a glance at other similar files when adding the version check but couldn't spot whatever it is that allows the page to update without a manual reload.

If you know where it is I should look for that reload check I can probably add it myself with a pointer, or feel free to edit my commit here directly (if you want to merge this PR, that is). Cheers :)