### PR TITLE
Fix #593

### DIFF
--- a/src/app/services/Resources.ts
+++ b/src/app/services/Resources.ts
@@ -43,7 +43,10 @@ export async function renderItem(version: VersionId, item: ItemStack, baseCompon
 		canvas.width = RENDER_SIZE
 		canvas.height = RENDER_SIZE
 		const resources = await getResources(version, baseComponents)
-		const gl = canvas.getContext('webgl2', { preserveDrawingBuffer: true })
+		const gl = canvas.getContext('webgl2', {
+			preserveDrawingBuffer: true,
+			premultipliedAlpha: false,
+		})
 		if (!gl) {
 			throw new Error('Cannot get WebGL2 context')
 		}

--- a/src/app/services/Resources1204.ts
+++ b/src/app/services/Resources1204.ts
@@ -39,7 +39,10 @@ export async function renderItem(version: VersionId, item: ItemStack) {
 		canvas.width = RENDER_SIZE
 		canvas.height = RENDER_SIZE
 		const resources = await getResources(version)
-		const gl = canvas.getContext('webgl2', { preserveDrawingBuffer: true })
+		const gl = canvas.getContext('webgl2', {
+			preserveDrawingBuffer: true,
+			premultipliedAlpha: false,
+		})
 		if (!gl) {
 			throw new Error('Cannot get WebGL2 context')
 		}


### PR DESCRIPTION
Fixes #593 

WebGL defaults to expecting premultiplied alpha, but the shaders output is straight alpha. Firefox's compositor seems to be strict about this mismatch, causing the visual artifacts.
Sets ``premultipliedAlpha`` to false to fix that.