### PR TITLE
Fix dialog display for varying-width children

### DIFF
--- a/src/app/components/previews/DialogPreview.tsx
+++ b/src/app/components/previews/DialogPreview.tsx
@@ -216,7 +216,7 @@ interface ColumnsGridProps {
 function ColumnsGrid({ columns, children }: ColumnsGridProps) {
 	const totalCount = children.length
 	const gridCount = Math.floor(totalCount / columns) * columns
-	return <div style={`padding-top: ${px(4)}; display: grid; grid-template-columns: repeat(${columns}, minmax(0, 1fr)); gap: ${px(2)}; justify-content: center;`}>
+	return <div style={`padding-top: ${px(4)}; display: grid; grid-template-columns: repeat(${columns}, auto); gap: ${px(2)}; justify-content: center; justify-items: center;`}>
 		{children.slice(0, gridCount)}
 		{totalCount > gridCount && <div style={`grid-column: span ${columns}; display: flex; gap: ${px(2)}; justify-content: center;`}>
 			{children.slice(gridCount)}


### PR DESCRIPTION
For the dialog:

```json
{
  "type": "minecraft:multi_action",
  "title": { "text": "Events, page 1 / n" },
  "exit_action": { "label": "" },
  "columns": 4,
  "actions": [
    { "label": "«", "width": 25 },
    { "label": "<", "width": 25 },
    { "label": ">", "width": 25 },
    { "label": "»", "width": 25 },

    { "label": "↑", "width": 25 },
    { "label": "↓", "width": 25 },
    { "label": "04.243: Chat" },
    { "label": "🗑", "width": 25 }
  ]
}
```

The generator (https://misode.github.io/dialog/) currently renders it as:

<img width="668" height="153" alt="image" src="https://github.com/user-attachments/assets/0238f04f-2e24-4fb4-83c9-1c9558bc4d01" />

But in-game (1.21.11), it renders as

<img width="643" height="280" alt="image" src="https://github.com/user-attachments/assets/db2eb1ed-69bd-4524-a0d0-2eafee287900" />

With this css fix, it renders in the generator like this, matching in-game view:

<img width="662" height="158" alt="image" src="https://github.com/user-attachments/assets/c85e2854-d6c1-41b4-a289-0f4b1314e013" />
